### PR TITLE
Implement asynchronous responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ failure = "0.1.1"
 log = "0.4"
 
 trust-dns = "0.15"
-trust-dns-proto = "0.5"
 
 serde = "1.0"
 serde_derive = "1.0"

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -1,8 +1,8 @@
+extern crate chrootable_https;
 extern crate env_logger;
 extern crate structopt;
-extern crate chrootable_https;
 
-use chrootable_https::{Resolver, Client};
+use chrootable_https::{Client, Resolver};
 use std::io;
 use std::io::prelude::*;
 use std::time::Duration;
@@ -10,7 +10,7 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Args {
-    #[structopt(short="-t", long="--timeout")]
+    #[structopt(short = "-t", long = "--timeout")]
     timeout: Option<u64>,
     urls: Vec<String>,
 }
@@ -27,8 +27,13 @@ fn main() {
     }
 
     for url in &args.urls {
-        let reply = client.get(&url).expect("request failed");
+        let reply = client
+            .get(&url)
+            .wait_for_response()
+            .expect("request failed");
         eprintln!("{:#?}", reply);
-        io::stdout().write(&reply.body).expect("failed to write body");
+        io::stdout()
+            .write(&reply.body)
+            .expect("failed to write body");
     }
 }

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -94,6 +94,7 @@ where
 }
 
 /// A Future representing work to connect to a URL
+#[must_use = "futures do nothing unless polled"]
 pub struct Connecting<T>(Box<Future<Item = (T, connect::Connected), Error = io::Error> + Send>);
 
 impl<T> Future for Connecting<T> {
@@ -106,6 +107,7 @@ impl<T> Future for Connecting<T> {
 }
 
 /// A Future representing work to resolve a DNS query
+#[must_use = "futures do nothing unless polled"]
 pub struct Resolving(Box<Future<Item = Destination, Error = Error> + Send>);
 
 impl Future for Resolving {

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -93,7 +93,7 @@ where
     }
 }
 
-/// A Future representing work to connect to a URL
+/// A Future representing work to connect to a URL.
 #[must_use = "futures do nothing unless polled"]
 pub struct Connecting<T>(Box<Future<Item = (T, connect::Connected), Error = io::Error> + Send>);
 
@@ -106,7 +106,7 @@ impl<T> Future for Connecting<T> {
     }
 }
 
-/// A Future representing work to resolve a DNS query
+/// A Future representing work to resolve a DNS query.
 #[must_use = "futures do nothing unless polled"]
 pub struct Resolving(Box<Future<Item = Destination, Error = Error> + Send>);
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -132,6 +132,7 @@ pub trait DnsResolver: Send + Sync {
     fn resolve(&self, name: &str, query_type: RecordType) -> Resolving;
 }
 
+/// An asynchronous DNS resolver.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Resolver {
     pub ns: Vec<SocketAddr>,

--- a/src/dns/system_conf/unix.rs
+++ b/src/dns/system_conf/unix.rs
@@ -1,19 +1,19 @@
 use errors::*;
 use resolv_conf;
 use std::fs;
-use std::net::{SocketAddr, IpAddr};
-
+use std::net::{IpAddr, SocketAddr};
 
 pub fn read_system_conf() -> Result<Vec<SocketAddr>> {
     let r = fs::read("/etc/resolv.conf")?;
     let conf = resolv_conf::Config::parse(&r)?;
 
-    let ns = conf.nameservers.into_iter()
+    let ns = conf
+        .nameservers
+        .into_iter()
         .map(|x| match x {
             resolv_conf::ScopedIp::V4(x) => IpAddr::V4(x),
             resolv_conf::ScopedIp::V6(x, _) => IpAddr::V6(x),
-        })
-        .map(|x| SocketAddr::new(x, 53))
+        }).map(|x| SocketAddr::new(x, 53))
         .collect();
     Ok(ns)
 }

--- a/src/dns/system_conf/windows.rs
+++ b/src/dns/system_conf/windows.rs
@@ -2,7 +2,6 @@ use errors::*;
 use ipconfig::get_adapters;
 use std::net::SocketAddr;
 
-
 pub fn read_system_conf() -> Result<Vec<SocketAddr>> {
     let ns = get_adapters()?
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,54 +12,56 @@
 //! let resolver = Resolver::cloudflare();
 //! let client = Client::new(resolver);
 //!
-//! let reply = client.get("https://httpbin.org/anything").expect("request failed");
+//! let reply = client.get("https://httpbin.org/anything").wait_for_response().expect("request failed");
 //! println!("{:#?}", reply);
 //! ```
 
 #![warn(unused_extern_crates)]
-pub extern crate hyper;
-pub extern crate http;
-extern crate tokio;
-extern crate rustls;
-extern crate hyper_rustls;
-extern crate webpki_roots;
-extern crate ct_logs;
-extern crate trust_dns;
-extern crate trust_dns_proto;
-extern crate futures;
 extern crate bytes;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate failure;
-#[macro_use] extern crate log;
+extern crate ct_logs;
+extern crate futures;
+pub extern crate http;
+pub extern crate hyper;
+extern crate hyper_rustls;
+extern crate rustls;
+extern crate tokio;
+extern crate trust_dns;
+extern crate webpki_roots;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate failure;
+#[macro_use]
+extern crate log;
 
-#[cfg(unix)]
-extern crate resolv_conf;
 #[cfg(windows)]
 extern crate ipconfig;
+#[cfg(unix)]
+extern crate resolv_conf;
 
-pub use hyper::Body;
-use http::response::Parts;
-pub use http::header;
-use hyper_rustls::HttpsConnector;
-use hyper::rt::Future;
-use hyper::client::connect::HttpConnector;
-pub use http::Request;
 use bytes::Bytes;
+pub use http::header;
+use http::response::Parts;
+pub use http::Request;
+use hyper::client::connect::HttpConnector;
+use hyper::rt::Future;
+pub use hyper::Body;
+use hyper_rustls::HttpsConnector;
 
-use tokio::runtime::Runtime;
+use futures::{future, Poll, Stream};
 use tokio::prelude::FutureExt;
-use futures::{future, Stream};
+use tokio::runtime::Runtime;
 
-use std::net::IpAddr;
+pub use http::Uri;
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-pub use http::Uri;
 
 mod connector;
 pub mod dns;
 use self::connector::Connector;
-pub use dns::{Resolver, DnsResolver, RecordType};
+pub use dns::{DnsResolver, RecordType, Resolver};
 
 pub mod errors {
     pub use failure::{Error, ResultExt};
@@ -67,19 +69,21 @@ pub mod errors {
 }
 pub use errors::*;
 
-
+/// A Client to make outgoing HTTP requests.
+///
+/// Uses an specific DNS resolver.
 #[derive(Debug)]
 pub struct Client<R: DnsResolver> {
     client: Arc<hyper::Client<HttpsConnector<Connector<HttpConnector>>>>,
-    resolver: R,
+    resolver: Arc<R>,
     records: Arc<Mutex<HashMap<String, IpAddr>>>,
     timeout: Option<Duration>,
 }
 
-impl<R: DnsResolver> Client<R> {
-    /// Create a new client with a specific dns resolver.
+impl<R: DnsResolver + 'static> Client<R> {
+    /// Create a new client with a specific DNS resolver.
     ///
-    /// This bypasses /etc/resolv.conf
+    /// This bypasses `/etc/resolv.conf`.
     pub fn new(resolver: R) -> Client<R> {
         let records = Arc::new(Mutex::new(HashMap::new()));
         let https = Connector::https(records.clone());
@@ -89,91 +93,165 @@ impl<R: DnsResolver> Client<R> {
 
         Client {
             client: Arc::new(client),
-            resolver,
+            resolver: Arc::new(resolver),
             records,
             timeout: None,
         }
     }
 
-    /// Set a timeout, default is no timeout
+    /// Set a timeout (default setting is no timeout).
     pub fn timeout(&mut self, timeout: Duration) {
         self.timeout = Some(timeout);
     }
 
-    /// Pre-populate the dns-cache. This function is usually called internally
-    pub fn pre_resolve(&self, uri: &Uri) -> Result<()> {
-        let host = match uri.host() {
-            Some(host) => host,
-            None => bail!("url has no host"),
-        };
+    /// Pre-populate the DNS cache. This function is usually called internally.
+    pub fn pre_resolve(&self, uri: Uri) -> PreResolving {
+        let resolver = self.resolver.clone();
+        let records = self.records.clone();
 
-        let record = self.resolver.resolve(&host, RecordType::A)?;
-        match record.success()?.into_iter().next() {
-            Some(record) => {
-                // TODO: make sure we only add the records we want
-                let mut cache = self.records.lock().unwrap();
-                cache.insert(host.to_string(), record);
-            },
-            None => bail!("no record found"),
-        }
-        Ok(())
+        let host = future::lazy(move || match uri.host() {
+            Some(host) => Ok(host.to_string()),
+            None => bail!("url has no host"),
+        });
+
+        let resolve = host.and_then(move |host| {
+            resolver
+                .resolve(&host, RecordType::A)
+                .map(|record| (host, record))
+        });
+
+        let cache = resolve.and_then(move |(host, record)| {
+            match record.success()?.into_iter().next() {
+                Some(record) => {
+                    // TODO: make sure we only add the records we want
+                    let mut cache = records.lock().unwrap_or_else(|x| x.into_inner());
+                    cache.insert(host.to_string(), record);
+                    Ok(())
+                }
+                None => bail!("no record found"),
+            }
+        });
+
+        PreResolving::new(cache)
     }
 
-    /// Shorthand function to do a GET request with [`HttpClient::request`]
+    /// Shorthand function to do a GET request with [`HttpClient::request`].
     ///
     /// [`HttpClient::request`]: trait.HttpClient.html#tymethod.request
-    pub fn get(&self, url: &str) -> Result<Response> {
-        let url = url.parse::<Uri>()?;
+    pub fn get(&self, url: &str) -> ResponseFuture {
+        let url = match url.parse::<Uri>() {
+            Ok(url) => url,
+            Err(e) => return ResponseFuture::new(future::err(e.into())),
+        };
 
         let mut request = Request::builder();
-        let request = request.uri(url)
-               .body(Body::empty())?;
+        let request = match request.uri(url).body(Body::empty()) {
+            Ok(request) => request,
+            Err(e) => return ResponseFuture::new(future::err(e.into())),
+        };
 
         self.request(request)
     }
 }
 
 impl Client<Resolver> {
-    /// Create a new client with the system resolver from /etc/resolv.conf
+    /// Create a new client with the system resolver from `/etc/resolv.conf`.
     pub fn with_system_resolver() -> Result<Client<Resolver>> {
         let resolver = Resolver::from_system()?;
         Ok(Client::new(resolver))
     }
 }
 
+/// Generic abstraction over HTTP clients.
 pub trait HttpClient {
-    fn request(&self, request: Request<hyper::Body>) -> Result<Response>;
+    fn request(&self, request: Request<hyper::Body>) -> ResponseFuture;
 }
 
-impl<R: DnsResolver> HttpClient for Client<R> {
-    fn request(&self, request: Request<hyper::Body>) -> Result<Response> {
-        info!("sending request to {:?}", request.uri());
-        self.pre_resolve(request.uri())?;
-
+impl<R: DnsResolver + 'static> HttpClient for Client<R> {
+    fn request(&self, request: Request<hyper::Body>) -> ResponseFuture {
         let client = self.client.clone();
         let timeout = self.timeout.clone();
 
-        let mut rt = Runtime::new()?;
-        let fut = client.request(request)
+        info!("sending request to {:?}", request.uri());
+        let fut = self
+            .pre_resolve(request.uri().clone())
+            .and_then(move |_| client.request(request).map_err(Error::from))
             .and_then(|res| {
                 debug!("http response: {:?}", res);
                 let (parts, body) = res.into_parts();
-                let body = body.concat2();
+                let body = body.concat2().map_err(Error::from);
                 (future::ok(parts), body)
-            });
+            }).map_err(|e| e.compat());
 
-        let (parts, body) = match timeout {
-            Some(timeout) => rt.block_on(fut.timeout(timeout))?,
-            None => rt.block_on(fut)?,
+        let fut: Box<Future<Item = _, Error = Error> + Send> = match timeout {
+            Some(timeout) => Box::new(fut.timeout(timeout).map_err(Error::from)),
+            None => Box::new(fut.map_err(Error::from)),
         };
 
-        let body = body.into_bytes();
-        let reply = Response::from((parts, body));
-        info!("got reply {:?}", reply);
-        Ok(reply)
+        let reply = fut.and_then(|(parts, body)| {
+            let body = body.into_bytes();
+            let reply = Response::from((parts, body));
+            info!("got reply {:?}", reply);
+            Ok(reply)
+        });
+
+        ResponseFuture::new(reply)
     }
 }
 
+/// A `Future` that represents a DNS query being pre-resolved and saved in the cache.
+#[must_use = "futures do nothing unless polled"]
+pub struct PreResolving(Box<Future<Item = (), Error = Error> + Send>);
+
+impl PreResolving {
+    /// Creates a new `PreResolving` future.
+    pub(crate) fn new<F>(inner: F) -> Self
+    where
+        F: Future<Item = (), Error = Error> + Send + 'static,
+    {
+        PreResolving(Box::new(inner))
+    }
+}
+
+impl Future for PreResolving {
+    type Item = ();
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.0.poll()
+    }
+}
+
+/// A `Future` that will resolve to an HTTP Response.
+#[must_use = "futures do nothing unless polled"]
+pub struct ResponseFuture(Box<Future<Item = Response, Error = Error> + Send>);
+
+impl ResponseFuture {
+    /// Creates a new `ResponseFuture`.
+    pub(crate) fn new<F>(inner: F) -> Self
+    where
+        F: Future<Item = Response, Error = Error> + Send + 'static,
+    {
+        ResponseFuture(Box::new(inner))
+    }
+
+    /// Drives this future to completion, eventually returning an HTTP response.
+    pub fn wait_for_response(self) -> Result<Response> {
+        let mut rt = Runtime::new()?;
+        rt.block_on(self)
+    }
+}
+
+impl Future for ResponseFuture {
+    type Item = Response;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.0.poll()
+    }
+}
+
+/// Represents an HTTP response.
 #[derive(Debug)]
 pub struct Response {
     pub status: u16,
@@ -187,9 +265,12 @@ impl From<(Parts, Bytes)> for Response {
         let parts = x.0;
         let body = x.1;
 
-        let cookies = parts.headers.get_all("set-cookie").into_iter()
-                        .flat_map(|x| x.to_str().map(|x| x.to_owned()).ok())
-                        .collect();
+        let cookies = parts
+            .headers
+            .get_all("set-cookie")
+            .into_iter()
+            .flat_map(|x| x.to_str().map(|x| x.to_owned()).ok())
+            .collect();
 
         let mut headers = HashMap::new();
 
@@ -213,19 +294,21 @@ impl From<(Parts, Bytes)> for Response {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use dns::Resolver;
-    use std::time::{Instant, Duration};
+    use std::time::{Duration, Instant};
 
     #[test]
     fn verify_200_http() {
         let resolver = Resolver::cloudflare();
 
         let client = Client::new(resolver);
-        let reply = client.get("http://httpbin.org/anything").expect("request failed");
+        let reply = client
+            .get("http://httpbin.org/anything")
+            .wait_for_response()
+            .expect("request failed");
         assert_eq!(reply.status, 200);
     }
 
@@ -234,14 +317,20 @@ mod tests {
         let resolver = Resolver::cloudflare();
 
         let client = Client::new(resolver);
-        let reply = client.get("https://httpbin.org/anything").expect("request failed");
+        let reply = client
+            .get("https://httpbin.org/anything")
+            .wait_for_response()
+            .expect("request failed");
         assert_eq!(reply.status, 200);
     }
 
     #[test]
     fn verify_200_https_system_resolver() {
         let client = Client::with_system_resolver().expect("failed to create client");
-        let reply = client.get("https://httpbin.org/anything").expect("request failed");
+        let reply = client
+            .get("https://httpbin.org/anything")
+            .wait_for_response()
+            .expect("request failed");
         assert_eq!(reply.status, 200);
     }
 
@@ -250,7 +339,10 @@ mod tests {
         let resolver = Resolver::cloudflare();
 
         let client = Client::new(resolver);
-        let reply = client.get("https://httpbin.org/redirect-to?url=/anything&status=302").expect("request failed");
+        let reply = client
+            .get("https://httpbin.org/redirect-to?url=/anything&status=302")
+            .wait_for_response()
+            .expect("request failed");
         assert_eq!(reply.status, 302);
     }
 
@@ -262,7 +354,7 @@ mod tests {
         client.timeout(Duration::from_millis(250));
 
         let start = Instant::now();
-        let _reply = client.get("http://1.2.3.4").err();
+        let _reply = client.get("http://1.2.3.4").wait_for_response().err();
         let end = Instant::now();
 
         assert!(end.duration_since(start) < Duration::from_secs(1));


### PR DESCRIPTION
### Added

* Create `ResponseFuture` and `PreResolving` types.
* Add `wait_for_response()` methods to certain futures, which drives them to completion using a `tokio::Runtime` and returns a `Result`, restoring the original synchronous behavior.

### Changed

* Make `Client`, `Connector`, and `Resolver` fully asynchronous.
* Update unit tests and `get.rs` example to use `wait_for_response()`.
* Add `Send + Sync` bounds on `DnsResolver` trait.
* Change `DnsResolver` to return a `Resolving` future.
* Removed some unnecessary clones by taking ownership instead of borrowing.
* Add `#[must_use]` attribute to all futures.
* Flesh out doc comments.
* Run `cargo fmt` on the codebase.

### Removed

* Delete unused `AsyncResolver` and `AsyncResolverFuture` types.
* Remove dependency on `trust-dns-proto` crate.

Closes #10.