### PR TITLE
Add dns cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ failure = "0.1.1"
 log = "0.4"
 
 trust-dns = "0.15"
+lru-cache = "0.1.1"
 
 serde = "1.0"
 serde_derive = "1.0"

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -22,20 +22,19 @@ fn main() {
     env_logger::init();
     let args = Args::from_args();
 
-    let mut client = if let Some(proxy) = args.socks5 {
+    let client = if let Some(proxy) = args.socks5 {
         Client::with_socks5(proxy)
     } else {
         let resolver = Resolver::cloudflare();
         Client::new(resolver)
     };
 
-    if let Some(timeout) = args.timeout {
-        client.timeout(Duration::from_millis(timeout));
-    }
+    let timeout = args.timeout.map(Duration::from_millis);
 
     for url in &args.urls {
         let reply = client
             .get(&url)
+            .with_timeout(timeout)
             .wait_for_response()
             .expect("request failed");
         eprintln!("{:#?}", reply);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -100,3 +100,36 @@ impl Default for DnsCache {
         DnsCache::new(32, TtlConfig::default())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn verify_insert() {
+        let now = Instant::now();
+        let mut cache = DnsCache::default();
+        let ipaddr = "1.1.1.1".parse().unwrap();
+        cache.insert("example.com".into(), Some(ipaddr), Duration::from_secs(1), now);
+    }
+
+    #[test]
+    fn verify_get() {
+        let now = Instant::now();
+        let mut cache = DnsCache::default();
+        let ipaddr = "1.1.1.1".parse().unwrap();
+        cache.insert("example.com".into(), Some(ipaddr), Duration::from_secs(1), now);
+        assert!(cache.get("example.com", now).is_some());
+    }
+
+    #[test]
+    fn verify_expire() {
+        let now = Instant::now();
+        let mut cache = DnsCache::default();
+        let ipaddr = "1.1.1.1".parse().unwrap();
+        cache.insert("example.com".into(), Some(ipaddr), Duration::from_secs(1), now);
+        let now = now + Duration::from_secs(2);
+        assert!(cache.get("example.com", now).is_none());
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,102 @@
+use lru_cache::LruCache;
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+
+/// https://tools.ietf.org/html/rfc2181,
+pub const MAX_TTL: u64 = 86400_u64;
+
+
+#[derive(Debug)]
+struct LruValue {
+    // this is None in case of an NX
+    ipaddr: Option<IpAddr>,
+    valid_until: Instant,
+}
+
+impl LruValue {
+    fn is_current(&self, now: Instant) -> bool {
+        now <= self.valid_until
+    }
+}
+
+pub struct TtlConfig {
+    pub positive_min_ttl: Duration,
+    pub negative_min_ttl: Duration,
+    pub positive_max_ttl: Duration,
+    pub negative_max_ttl: Duration,
+}
+
+impl Default for TtlConfig {
+    fn default() -> TtlConfig {
+        TtlConfig {
+            positive_min_ttl: Duration::from_secs(0),
+            negative_min_ttl: Duration::from_secs(0),
+            positive_max_ttl: Duration::from_secs(MAX_TTL),
+            negative_max_ttl: Duration::from_secs(MAX_TTL),
+        }
+    }
+}
+
+pub struct DnsCache {
+    cache: LruCache<String, LruValue>,
+    positive_min_ttl: Duration,
+    negative_min_ttl: Duration,
+    positive_max_ttl: Duration,
+    negative_max_ttl: Duration,
+}
+
+impl DnsCache {
+    pub fn new(capacity: usize, ttl: TtlConfig) -> DnsCache {
+        let cache = LruCache::new(capacity);
+        DnsCache {
+            cache,
+            positive_min_ttl: ttl.positive_min_ttl,
+            negative_min_ttl: ttl.negative_min_ttl,
+            positive_max_ttl: ttl.positive_max_ttl,
+            negative_max_ttl: ttl.negative_max_ttl,
+        }
+    }
+
+    pub fn insert(&mut self, query: String, ipaddr: Option<IpAddr>, mut ttl: Duration, now: Instant) {
+        if ipaddr.is_some() {
+            if ttl < self.positive_min_ttl {
+                ttl = self.positive_min_ttl.clone();
+            } else if ttl > self.positive_max_ttl {
+                ttl = self.positive_max_ttl.clone();
+            }
+        } else {
+            if ttl < self.negative_min_ttl {
+                ttl = self.negative_min_ttl.clone();
+            } else if ttl > self.negative_max_ttl {
+                ttl = self.negative_max_ttl.clone();
+            }
+        }
+
+        let valid_until = now + ttl;
+
+        self.cache.insert(query, LruValue {
+            ipaddr,
+            valid_until,
+        });
+    }
+
+    pub fn get(&mut self, query: &str, now: Instant) -> Option<Option<IpAddr>> {
+        if let Some(ipaddr) = self.cache.get_mut(query) {
+            if !ipaddr.is_current(now) {
+                self.cache.remove(query);
+                None
+            } else {
+                Some(ipaddr.ipaddr)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for DnsCache {
+    fn default() -> DnsCache {
+        DnsCache::new(32, TtlConfig::default())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub mod cache;
 mod connector;
 pub mod dns;
 pub mod socks5;


### PR DESCRIPTION
I ran into issues because:

- keepalive is disabled (see #14)
- each connection triggers a new dns lookup
- too many dns lookups can trigger rate limits

This also works around a udp socket leak that I still couldn't fix without trust-dns/hyper/tokio interfering with each other.